### PR TITLE
Fixed parsing FRACSEC; Removed any null character in the station name

### DIFF
--- a/pymu/pmuConfigFrame.py
+++ b/pymu/pmuConfigFrame.py
@@ -120,7 +120,7 @@ class Station:
     def parseSTN(self):
         """Parses station name field"""
         l = 32
-        self.stn = bytes.fromhex(self.stationFrame[self.length:self.length+l]).decode('ascii')
+        self.stn = bytes.fromhex(self.stationFrame[self.length:self.length+l]).decode('ascii').replace('\x00', '')
         self.updateLength(l)
         print("STN: ", self.stn, sep="") if self.dbg else None
 

--- a/pymu/pmuFrame.py
+++ b/pymu/pmuFrame.py
@@ -66,9 +66,11 @@ class PMUFrame:
 
     def parseFRACSEC(self):
         """Parse fraction of second and time quality word"""
-        fracsecSize = 8
-        self.fracsec = int(self.frame[self.length:self.length+fracsecSize], 16)
-        self.updateLength(fracsecSize)
+        fracsecSize = 6
+        messageTimeQualitySize = 2
+        self.message_time_quality = int(self.frame[self.length:self.length + messageTimeQualitySize], 16)
+        self.fracsec = int(self.frame[self.length + messageTimeQualitySize:self.length + messageTimeQualitySize + fracsecSize], 16)
+        self.updateLength(messageTimeQualitySize + fracsecSize)
         print("FRACSEC: ", self.fracsec) if self.dbg else None
 
     def parseCHK(self):


### PR DESCRIPTION
Hello,

I am using the library to communicate with my micro PMU sensor. Thank you for sharing it. While I am working with the library, I noticed two things that need to be fixed. I fixed them and it works fine after that. I would like to share this and possibly hope that these fixes can be merged to your repository to improve the library. Below are some descriptions on what are fixed.

1) my Micro PMU reported its station name along with some null characters (`0x00`) within the name (e.g., station\x00-zero). It would be safer to remove any null character from its name when we use or store the name into a file, which can raise an exception.

2) The FRACSEC field is not parsed correctly. The FRACSEC field should only contain 3 bytes positioned after 1byte of MESSAGE_TIME_QUALITY field.