### PR TITLE
Frame size fix

### DIFF
--- a/pymu/tools.py
+++ b/pymu/tools.py
@@ -80,8 +80,10 @@ def getDataSample(rcvr, debug=False):
     fullHexStr = ""
 
     if isinstance(rcvr, Client):
-        introHexStr = bytesToHexStr(rcvr.readSample(4))
-        lenToRead = int(introHexStr[5:], 16)
+        introHexStrSize = 4
+        introHexStr = bytesToHexStr(rcvr.readSample(introHexStrSize))
+        totalFrameLength = int(introHexStr[5:], 16)
+        lenToRead = totalFrameLength - introHexStrSize
         remainingHexStr = bytesToHexStr(rcvr.readSample(lenToRead))
 
         fullHexStr = introHexStr + remainingHexStr

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from os import path
 here = path.abspath(path.dirname(__file__))
 
 # Get the long description from the README file
-with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
+with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(


### PR DESCRIPTION
Corrected an issue in `setup.py` wherein it searches for `README.rst` instead of `README.md`.

Corrected the interpretation of the `FRAMESIZE` field in the `tools.py` file. `FRAMESIZE` refers to the total size of the frame, including the `SYNC` and `FRAMESIZE` sections, not just the remaining bytes in the frame.
![image](https://user-images.githubusercontent.com/17257092/160201305-03bf6d21-0aec-486f-ba64-ebed5a619c57.png)


This lead to the intermittent issue of over-reading bytes from the buffer resulting in malformed frames. Further work could be done to prevent under-reading conditions (`socket.recv()` can return fewer bytes than requested if the buffer is drained, hence why the former implementation worked most of the time).